### PR TITLE
Improvement: Add build info to README and notes on 800V

### DIFF
--- a/chademo/chademoCharger.h
+++ b/chademo/chademoCharger.h
@@ -20,7 +20,7 @@
 #include "printf.h"
 
 #define ADAPTER_MAX_AMPS 200
-#define ADAPTER_MAX_VOLTS 500
+#define ADAPTER_MAX_VOLTS 500 //Porsche Taycan requires 750V, but setting this value to 750 might break compatibility with many chargers. As default value 500V is good!
 
 template<typename T>
 constexpr T min(T a, T b) {
@@ -392,6 +392,7 @@ struct CarData
     /// 0: before 0.9
     /// 1: 0.9, 0.9.1
     /// 2: 1.0.0, 1.0.1
+    /// 3: 2.0
     /// </summary>
     uint8_t ProtocolNumber;
 
@@ -402,7 +403,7 @@ struct CarData
 
 struct ChargerData
 {
-    uint8_t ProtocolNumber = 2; // 1: chademo 0.9 2: chademo 1.0
+    uint8_t ProtocolNumber = 2; // 1: chademo 0.9 2: chademo 1.0 3: chademo 2.0
 
     /// <summary>
     /// Initial status is stopped

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,22 @@ Happy hacking.
 Every commit is built automatically and can be downloaded here, as artifact of a workflow run: [https://github.com/osexpert/ccs32clara-chademo/actions](https://github.com/osexpert/ccs32clara-chademo/actions?query=branch%3Amain)
 Releases are made less often and the difference is, a release has been tested in minimum one charging session on a Leaf 40kwh.
 
+## Building
+If you want to compile the software from scratch, you can follow these instructions
+
+### Linux
+
+- git clone https://github.com/osexpert/ccs32clara-chademo.git
+- cd into directory ccs32clara-chademo
+- git submodule init
+- git submodule update
+- sudo apt install gcc-arm-none-eabi
+- bash
+- make get-deps
+- make
+
+This will output a My407ccs2chademo.bin file that you can flash onto the adapter
+
 # ccs32clara
 
 ![image](doc/clara_logo_colored.jpg) Hi, I'm Clara. I'm a piece of software, which was born in the OpenInverter forum community, https://openinverter.org/forum/viewtopic.php?t=3727, and I'm loving to grow due to the great people there.


### PR DESCRIPTION
### What
This PR updates the Readme.md file to include info on how to build the firmware. It also adds a note on Porsche 800V charging

### Why
- Makes it easier for people to contribute to the codebase, by having easy setup info
- JDM versions of the Porsche Taycan needs to have the firmware built for 800V mode in order to work. This is just added as a note, since forcing 800V mode can break compatibility with existing chargers, so keeping the chademo max voltage at 500V is still recommended