### PR TITLE
Update readme.md with compatibility info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,13 @@ This is ccs32clara derived firmware for Dongguan Longood CCS2 to CHAdeMO adapter
 The firmware is compatible with the "Dongguan Longgod" adapter variants. If your adapter accepts firmware updates in the form of "My407ccs2chademo.bin" files, it is supported. Note that there are many adapter brands and re-brands on the market.
 
 - Dongguan Longgod ✅
+   - CCS1 US ✅
+   - CCS2 EU ✅
 - EV-Boy (rebrand) ✅
 - Akyga® AK-SC-E18 (rebrand) ✅
 - Electway :x: Not compatible
 - A2Z :x: Not compatible
+- Orientrise :x: Not compatible
 - Feel free to expand this list!
 
 The adapter uses an STM32F407 cpu. It has a bootloader with support for firmware update from USB FAT32, very nice.


### PR DESCRIPTION
### What
This PR updates the readme with further info on firmware compatibility

### Why
The firmware was recently tested on US CCS1 version of the adapter, with this feedback:

_confirming this worked for me in the US.  the manufacturer was clueless and the adapter never worked until this update.  i'll buy the author of this firmware a beer if i get the chance._

### How
Fields for CCS1 and CCS2 added. Also added note that the Orientrise adapter is NOT compatible, due to it being an A2Z derivative