### PR TITLE
(try to) improve welding detection

### DIFF
--- a/ccs/hardwareInterface.cpp
+++ b/ccs/hardwareInterface.cpp
@@ -38,11 +38,13 @@ bool hardwareInterface_getIsBatteryFull(void)
 void hardwareInterface_setPowerRelayOn(void)
 {
     println("hardwareInterface_setPowerRelayOn");
+    _ccs_params.PowerRelayOn = true;
 }
 
 void hardwareInterface_setPowerRelayOff(void)
 {
     println("hardwareInterface_setPowerRelayOff");
+    _ccs_params.PowerRelayOn = false;
 }
 
 void hardwareInterface_setStateB(void)
@@ -57,23 +59,21 @@ void hardwareInterface_setStateC(void)
     DigIo::state_c_out_inverted.Clear();
 }
 
-static bool _connectorLocked = false;
-
 void hardwareInterface_lockConnector(void)
 {
     println("[ccs] Lock charging plug");
-    _connectorLocked = true;
+    _ccs_params.ConnectorLocked = true;
 }
 
 void hardwareInterface_unlockConnector(void)
 {
     println("[ccs] Unlock charging plug");
-    _connectorLocked = false;
+    _ccs_params.ConnectorLocked = false;
 }
 
 bool hardwareInterface_isConnectorLocked(void)
 {
-    return _connectorLocked;
+    return _ccs_params.ConnectorLocked;
 }
 
 bool hardwareInterface_stopChargeRequested()

--- a/ccs/pevStateMachine.cpp
+++ b/ccs/pevStateMachine.cpp
@@ -22,6 +22,7 @@
    STATE_ENTRY(WaitForCurrentDemandResponse, CurrentDemand, 5) /* Test with 5s timeout. Just experimental. The specified performance time is 25ms (ISO), the specified timeout 250ms. */\
    STATE_ENTRY(WaitForPowerDeliveryOffResponse, PowerDeliveryOff, 6) /* PowerDelivery may need some time. Wait at least 6s. On Compleo charger, observed more than 1s until response. specified performance time is 4.5s (ISO) */\
    STATE_ENTRY(WaitForCurrentDownAfterStateB, CurrentDown, 60) \
+   STATE_ENTRY(WaitForPowerRelayOff, RelayOff, 60) \
    STATE_ENTRY(WaitForWeldingDetectionResponse, WeldingDetection, 2) \
    STATE_ENTRY(WaitForSessionStopResponse, SessionStop, 2) \
    STATE_ENTRY(SafeShutDown, SafeShutDown, 0) \
@@ -975,11 +976,20 @@ static void stateFunctionWaitForCurrentDownAfterStateB(void)
         pev_DelayCycles--;
         return;
     }
-    if (chademoInterface_carContactorsOpened()) {
-        /* Time is over. Current flow should have been stopped by the charger. Let's open the contactors and send a weldingDetectionRequest, to find out whether the voltage drops. */
+
+    /* Time is over. Current flow should have been stopped by the charger. Let's open the contactors and send a weldingDetectionRequest, to find out whether the voltage drops. */
+    hardwareInterface_setPowerRelayOff();
+    setCheckpoint(850);
+    pev_enterState(PEV_STATE_WaitForPowerRelayOff);
+}
+
+static void stateFunctionWaitForPowerRelayOff(void)
+{
+    // Wait for chademo to ACK _ccs_params.ContactorClosed we sat in hardwareInterface_setPowerRelayOff()
+    if (chademoInterface_adapterContactorOpened())
+    {
         addToTrace(MOD_PEV, "Starting WeldingDetection");
-        hardwareInterface_setPowerRelayOff();
-        setCheckpoint(850);
+
         /* We do not need a waiting time before sending the weldingDetectionRequest, because the weldingDetection
         will be anyway in a loop. So the first round will see a high voltage (because the contactor mechanically needed
         some time to open, but this is no problem, the next samples will see decreasing voltage in normal case. */

--- a/ccs/pevStateMachine.h
+++ b/ccs/pevStateMachine.h
@@ -16,7 +16,7 @@ extern void pevStateMachine_reset();
 
 // naming: _ccsXxx if the method is impemented in ccs. Else in chademo.
 extern bool chademoInterface_preChargeCompleted();
-extern bool chademoInterface_carContactorsOpened();
+extern bool chademoInterface_adapterContactorOpened();
 extern bool chademoInterface_ccsInStateEnd();
 extern bool chademoInterface_ccsChargingVoltageMirrorsTarget();
 extern bool chademoInterface_ccsChargingCurrentMirrorsTarget();

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -1095,8 +1095,7 @@ void ChademoCharger::UpdateChargerMessages()
     // ZE0 seems to hangs the second time, if discharge is enabled during discovery
     COMPARE_SET(_msg109.m.DischargeCompatible, _dischargeEnabled && not _discovery, "109.DischargeCompatible %d -> %d");
 
-    // real outVolt after car contactors close. Before this, use the simulated volt (currently always 0).
-    uint16_t outputVolt = _state > ChargerState::WaitForCarContactorsClosed ? _chargerData.OutputVoltage : 0;
+    uint16_t outputVolt = _reportOutputVoltage ? _chargerData.OutputVoltage : 0;
     COMPARE_SET(_msg109.m.PresentVoltage, outputVolt, "109.OutputVoltage %d -> %d");
 
     uint8_t remainingChargingTime10s = 0;

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -987,7 +987,6 @@ void ChademoCharger::HandleCanMessageIsr(uint32_t id, uint32_t data[2])
         _msg201_isr.pair[1] = data[1];
         _msg201_pending = true;
     }
-    _global.canLifesign = true;
 }
 
 

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -480,6 +480,7 @@ void ChademoCharger::RunStateMachine()
 
             println("[cha] Car contactors closed");
             _carData.CarContactorsClosed = true;
+            _reportOutputVoltage = true; // let car "see"  the charger voltage
 
             if (_global.CHADEMO_SX)
             {
@@ -709,7 +710,19 @@ void ChademoCharger::RunStateMachine()
             _chargerData.DischargeCurrent = 0;
             _chargerData.RemainingDischargeTime = 0;
 
+            // When car sees this flag cleared and OutputCurrent <= 5, car will start welding detection
             clear_flag(&_chargerData.Status, ChargerStatus::CHARGING);
+
+            SetState(ChargerState::Stopping_WaitToOpenAdapterContactor);
+        }
+    }
+    else if (_state == ChargerState::Stopping_WaitToOpenAdapterContactor)
+    {
+        // Wait for hardwareInterface_setPowerRelayOff() being called, we mirror its state, but we can't wait for too long...
+        if (not _ccs_params.PowerRelayOn || IsTimeoutSec(4))
+        {
+            OpenAdapterContactor();
+            _reportOutputVoltage = false; // show 0 volt on CAN as well, regardless of chargers real output voltage
 
             if (_carData.ProtocolNumber >= ProtocolNumber::Chademo_1_0)
                 SetState(ChargerState::Stopping_WaitForCarContactorsOpen);
@@ -750,18 +763,6 @@ void ChademoCharger::RunStateMachine()
         {
             SetSwitchD1(false);
 
-            SetState(ChargerState::Stopping_WaitForLowVolts);
-        }
-    }
-    else if (_state == ChargerState::Stopping_WaitForLowVolts)
-    {
-        // C-time <= 2.0s / T-time 4.0s
-        // cha spec says <= 10V but we need to play by ccs rules here. Seen some chargers never drop below 28V. Clara uses 40V.
-        // This check may be completely pointless?
-        if (_chargerData.OutputVoltage < MAX_VOLTAGE_TO_FINISH_WELDING_DETECTION || IsTimeoutSec(4))
-        {
-            OpenAdapterContactor();
-
             // stop CAN in later state to make sure we send this message to car before we kill CAN
             clear_flag(&_chargerData.Status, ChargerStatus::ENERGIZING_OR_PLUG_LOCKED);
 
@@ -770,6 +771,7 @@ void ChademoCharger::RunStateMachine()
     }
     else if (_state == ChargerState::Stopping_UnlockChargingPlug)
     {
+        // Unlock charging plug in own state, to make sure the car get the CAN message before power off (plug unlocked = power off ok)
     	UnlockChargingPlug();
 
         SetState(ChargerState::End);
@@ -807,14 +809,14 @@ bool chademoInterface_preChargeCompleted()
     return chademoCharger->PreChargeCompleted();
 }
 
-bool ChademoCharger::CarContactorsOpened()
+bool ChademoCharger::AdapterContactorOpened()
 {
-    return not _carData.CarContactorsClosed;
+    return not _adapterContactorClosed;
 }
 
-bool chademoInterface_carContactorsOpened()
+bool chademoInterface_adapterContactorOpened()
 {
-    return chademoCharger->CarContactorsOpened();
+    return chademoCharger->AdapterContactorOpened();
 }
 
 int ChademoCharger::GetChargingLoopPos()

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -713,10 +713,10 @@ void ChademoCharger::RunStateMachine()
             // When car sees this flag cleared and OutputCurrent <= 5, car will start welding detection
             clear_flag(&_chargerData.Status, ChargerStatus::CHARGING);
 
-            SetState(ChargerState::Stopping_WaitToOpenAdapterContactor);
+            SetState(ChargerState::Stopping_WaitForCcsPowerRelayOff);
         }
     }
-    else if (_state == ChargerState::Stopping_WaitToOpenAdapterContactor)
+    else if (_state == ChargerState::Stopping_WaitForCcsPowerRelayOff)
     {
         // Wait for hardwareInterface_setPowerRelayOff() being called, we mirror its state, but we can't wait for too long...
         if (not _ccs_params.PowerRelayOn || IsTimeoutSec(4))

--- a/chademo/chademoCharger.h
+++ b/chademo/chademoCharger.h
@@ -214,8 +214,7 @@ enum class StopReason
     CHARGER_STATE(ChargingLoop) \
     CHARGER_STATE(Stopping_Start) \
     CHARGER_STATE(Stopping_WaitForLowAmps) \
-    CHARGER_STATE(Stopping_WaitToOpenAdapterContactor) \
-    CHARGER_STATE(Stopping_OpenAdapterContactor) \
+    CHARGER_STATE(Stopping_WaitForCcsPowerRelayOff) \
     CHARGER_STATE(Stopping_WaitForSwitchKOff) \
     CHARGER_STATE(Stopping_WaitForCarContactorsOpen) \
     CHARGER_STATE(Stopping_SetSwitchD1Off) \

--- a/chademo/chademoCharger.h
+++ b/chademo/chademoCharger.h
@@ -214,10 +214,11 @@ enum class StopReason
     CHARGER_STATE(ChargingLoop) \
     CHARGER_STATE(Stopping_Start) \
     CHARGER_STATE(Stopping_WaitForLowAmps) \
+    CHARGER_STATE(Stopping_WaitToOpenAdapterContactor) \
+    CHARGER_STATE(Stopping_OpenAdapterContactor) \
     CHARGER_STATE(Stopping_WaitForSwitchKOff) \
     CHARGER_STATE(Stopping_WaitForCarContactorsOpen) \
     CHARGER_STATE(Stopping_SetSwitchD1Off) \
-    CHARGER_STATE(Stopping_WaitForLowVolts) \
     CHARGER_STATE(Stopping_UnlockChargingPlug) \
     CHARGER_STATE(End)
 
@@ -668,7 +669,7 @@ public:
     int GetCyclicOffset();
     bool IsPowerOffOk();
     bool PreChargeCompleted();
-    bool CarContactorsOpened();
+    bool AdapterContactorOpened();
     int GetChargingLoopPos();
     void UpdateChargerMessages();
     void HandlePendingCarMessages();
@@ -753,6 +754,7 @@ public:
         bool _chargingPlugLocked = false;
         bool _msg102_recieved = false;
         bool _send_can = false;
+        bool _reportOutputVoltage = false;
         bool _d1 = false;
         bool _d2 = false;
         bool _adapterContactorClosed = false;

--- a/src/ccs_params.h
+++ b/src/ccs_params.h
@@ -67,6 +67,9 @@ struct ccs_params
             EvseMaxCurrent :
             EvseMaxCurrentInCurrentDemandRes;
     }
+
+    bool PowerRelayOn = false;
+    bool ConnectorLocked = false;
 };
 
 extern ccs_params _ccs_params;

--- a/src/main.h
+++ b/src/main.h
@@ -54,7 +54,6 @@ struct global_data
     uint32_t auto_power_off_timer_count_up_ms = 0;
 
     bool ccsLifesign = false;
-    bool canLifesign = false;
 };
 
 extern global_data _global;


### PR DESCRIPTION
Some mitsubishi cars DTC, probably because of failed welding detection.
The specs is kind of confusing on the matter and most cars don'r care,
but try to use logic:
- CONTACTOR_OPEN_OR_WELDING_DETECTION_DONE is ment to be set at the end of welding detection
- car open its contactors before this to measure the inlet voltage. If they measure some, they think they measure the battery = welded
- for this to work, the charger must have dropped its volts massively, before (or shortly after) clearing ChargerStatus::CHARGING

So try to do this, and at the same time, try to interlock with ccs.

Also drop reported outputvoltage immediately after adapter contactor opened

