### PR TITLE
ZombieVerter Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+My407ccs2chademo
+My407ccs2chademo.bin
+
 # Eclipse
 .metadata
 .settings

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -88,6 +88,7 @@ void ChademoCharger::HandlePendingCarMessages()
     static msg100 _msg100 = {};
     static msg101 _msg101 = {};
     static msg102 _msg102 = {};
+    static msg103 _msg103 = {};
     static msg110 _msg110 = {};
     static msg200 _msg200 = {};
     static msg201 _msg201 = {};
@@ -198,6 +199,15 @@ void ChademoCharger::HandlePendingCarMessages()
         }
 
         _msg102_recieved = true;
+    }
+    if (_msg103_pending)
+    {
+        _msg103_pending = false;
+
+        COMPARE_SET(_msg103.m.BatteryVoltage, _msg103_isr.m.BatteryVoltage, "103.BatteryVoltage %d -> %d");
+
+        _carData.EstimatedBatteryVoltage = _msg103.m.BatteryVoltage;
+        _carData.EstimatedBatteryVoltageSet = true;
     }
     if (_msg110_pending)
     {
@@ -966,6 +976,12 @@ void ChademoCharger::HandleCanMessageIsr(uint32_t id, uint32_t data[2])
         _msg102_isr.pair[0] = data[0];
         _msg102_isr.pair[1] = data[1];
         _msg102_pending = true;
+    }
+    else if (id == 0x103)
+    {
+        _msg103_isr.pair[0] = data[0];
+        _msg103_isr.pair[1] = data[1];
+        _msg103_pending = true;
     }
     else if (id == 0x110)
     {

--- a/chademo/chademoCharger.cpp
+++ b/chademo/chademoCharger.cpp
@@ -188,14 +188,16 @@ void ChademoCharger::HandlePendingCarMessages()
             // now that TargetVoltage is stable, set overrides, if any
             SetBatteryVoltOverridesOnce();
 
-            _carData.EstimatedBatteryVoltage = GetEstimatedBatteryVoltage(_carData.TargetVoltage, 
-                _carData.SocPercent, 
-                _carData.NomVoltOverride, 
-                _carData.MaxVoltOverride,
-                _carData.AdjustBelowSoc, 
-                _carData.AdjustBelowFactor);
+            if (not _carData.EstimatedBatteryVoltageOverride) {
+                _carData.EstimatedBatteryVoltage = GetEstimatedBatteryVoltage(_carData.TargetVoltage, 
+                    _carData.SocPercent, 
+                    _carData.NomVoltOverride, 
+                    _carData.MaxVoltOverride,
+                    _carData.AdjustBelowSoc, 
+                    _carData.AdjustBelowFactor);
 
-            _carData.EstimatedBatteryVoltageSet = true;
+                _carData.EstimatedBatteryVoltageSet = true;
+            }
         }
 
         _msg102_recieved = true;
@@ -208,6 +210,7 @@ void ChademoCharger::HandlePendingCarMessages()
 
         _carData.EstimatedBatteryVoltage = _msg103.m.BatteryVoltage;
         _carData.EstimatedBatteryVoltageSet = true;
+        _carData.EstimatedBatteryVoltageOverride = true;
     }
     if (_msg110_pending)
     {

--- a/chademo/chademoCharger.h
+++ b/chademo/chademoCharger.h
@@ -291,6 +291,23 @@ struct msg102
     };
 };
 
+// Battery Voltage
+struct msg103
+{
+    union {
+        struct {
+            uint16_t BatteryVoltage;
+            uint8_t Unused2;
+            uint8_t Unused3;
+            uint8_t Unused4;
+            uint8_t Unused5;
+            uint8_t Unused6;
+            uint8_t Unused7;
+        } m;
+        uint8_t bytes[8];
+        uint32_t pair[2];
+    };
+};
 
 // Car extension
 struct msg110
@@ -772,6 +789,8 @@ public:
         msg101 _msg101_isr = {};
         volatile bool _msg102_pending = false;
         msg102 _msg102_isr = {};
+        volatile bool _msg103_pending = false;
+        msg103 _msg103_isr = {};
         volatile bool _msg110_pending = false;
         msg110 _msg110_isr = {};
         volatile bool _msg200_pending = false;

--- a/chademo/chademoCharger.h
+++ b/chademo/chademoCharger.h
@@ -560,6 +560,7 @@ struct CarData
 
     uint16_t EstimatedBatteryVoltage;
     bool EstimatedBatteryVoltageSet = false;
+    bool EstimatedBatteryVoltageOverride = false;
 
     uint16_t CyclesSinceCarLastRequestCurrent;
 


### PR DESCRIPTION
Allows actual vehicle battery voltage to be read from CHAdeMO CAN bus when available.